### PR TITLE
Returning ACCData object instead of dict

### DIFF
--- a/polar_python/parsers/accelerometer.py
+++ b/polar_python/parsers/accelerometer.py
@@ -2,11 +2,12 @@
 
 from typing import List
 from .compression import parse_delta_frames_all
+from .. import constants
 
 
 def parse_acc_data(
     data: List[int], timestamp: int, frame_type: int, factor: float = 1.0
-) -> dict:
+) -> constants.ACCData:
     """Parse accelerometer data from a list of integers based on frame type."""
     is_compressed = (frame_type & 0x80) != 0
     actual_frame_type = frame_type & 0x7F
@@ -19,7 +20,7 @@ def parse_acc_data(
         return parse_raw_acc_data(data, timestamp, actual_frame_type)
 
 
-def parse_raw_acc_data(data: List[int], timestamp: int, frame_type: int) -> dict:
+def parse_raw_acc_data(data: List[int], timestamp: int, frame_type: int) -> constants.ACCData:
     """Parse raw (non-compressed) accelerometer data.
 
     For raw data, the device sends values in the correct units (milliG),
@@ -67,12 +68,12 @@ def parse_raw_acc_data(data: List[int], timestamp: int, frame_type: int) -> dict
                 )
                 acc_data.append((x, y, z))
 
-    return {"timestamp": timestamp, "data": acc_data}
+    return constants.ACCData(timestamp=timestamp, data=acc_data)
 
 
 def parse_compressed_acc_data(
     data: List[int], timestamp: int, frame_type: int, factor: float
-) -> dict:
+) -> constants.ACCData:
     """Parse compressed accelerometer data."""
     if frame_type == 0x00:  # Compressed TYPE_0
         # type 0 data arrives in G units, convert to milliG
@@ -99,4 +100,4 @@ def parse_compressed_acc_data(
     else:
         raise ValueError(f"Unsupported compressed frame type: {frame_type}")
 
-    return {"timestamp": timestamp, "data": acc_data}
+    return constants.ACCData(timestamp=timestamp, data=acc_data)


### PR DESCRIPTION
In the accelerometer, I'm changing the parse functions to return the `ACCData` data object instead of dict. Now, it's in the same format as the other PMD measurement types. Not sure if you are aware of this and even if it's possible to contribute in this project but for sure I'm interested. Cheers!

**Before**:
<img width="616" height="17" alt="Captura de Tela 2026-02-22 às 17 56 11" src="https://github.com/user-attachments/assets/9b64d80f-5629-4e0d-adc0-c7635b355368" />

**After**:
<img width="626" height="17" alt="Captura de Tela 2026-02-22 às 17 56 39" src="https://github.com/user-attachments/assets/7f01477b-4e8a-4c6e-830d-57f3948dac88" />
